### PR TITLE
Issue 56: Do no replace double-quotes with single-quotes and do not replace multple consecutive spaces.

### DIFF
--- a/src/service/workflow.service.ts
+++ b/src/service/workflow.service.ts
@@ -109,9 +109,7 @@ class WorkflowService extends RestService implements Enhancer {
       const script = fileService.read(`${path}/js/${obj[prop]}`).trim();
       obj[prop] = templateService.template(script)
         // remove all endline characters
-        .replace(/(\r\n|\n|\r)/gm, '')
-        // remove all extraneous double spaces
-        .replace(/\s\s+/g, ' ');
+        .replace(/(\r\n|\n|\r)/gm, '');
     }
   }
 

--- a/src/service/workflow.service.ts
+++ b/src/service/workflow.service.ts
@@ -111,9 +111,7 @@ class WorkflowService extends RestService implements Enhancer {
         // remove all endline characters
         .replace(/(\r\n|\n|\r)/gm, '')
         // remove all extraneous double spaces
-        .replace(/\s\s+/g, ' ')
-        // replace all double quotes with single quotes
-        .replace(/"/g, '\'');
+        .replace(/\s\s+/g, ' ');
     }
   }
 


### PR DESCRIPTION
resolves #56 

Replacing single-quotes with double-quotes breaks scripts, such as JavaScript.
Remove the code that performs the replacement.

The user should be expected to properly construct the json files with single-quotes.

Replacing multiple consecutive spaces with a single space will break language like Python.
Special strings, such as a quote SQL string, may also break.
Remove the code that performs the replacement.
