### PR TITLE
Issue 66: Logout should delete both `folioRefreshToken` and `folioAccessToken`.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,8 @@ program
   .description('logout to remove token from config')
   .action(() => {
     config.delete('token');
+    config.delete('folioAccessToken');
+    config.delete('folioRefreshToken');
     console.log('success');
   });
 


### PR DESCRIPTION
The commit 2142c18326c35349ace4be001a0fa745783f4d14 introduced both `folioRefreshToken` and `folioAccessToken` to address compatibility with upcoming folio behavior. The `logout` action was overlooked.

Make sure that these two new tokens are deleted on logout.