### PR TITLE
Issue 68: Implement redirect handling.

### DIFF
--- a/src/service/rest.service.ts
+++ b/src/service/rest.service.ts
@@ -27,14 +27,7 @@ export class RestService {
         } else {
           const promise = this.redirectRecurse(url, json, contentType, accept, response, this.get, redirectCount + 1);
           if (promise) {
-            promise.then((result) => {
-              resolve(result);
-            })
-            .catch ((err) => {
-              reject(err);
-            });
-
-            return promise;
+            return this.resolveRedirectPromise(promise, resolve, reject);
           }
 
           // console.log('failed get', url);
@@ -64,14 +57,7 @@ export class RestService {
         } else {
           const promise = this.redirectRecurse(url, json, contentType, accept, response, this.post, redirectCount + 1);
           if (promise) {
-            promise.then((result) => {
-              resolve(result);
-            })
-            .catch ((err) => {
-              reject(err);
-            });
-
-            return promise;
+            return this.resolveRedirectPromise(promise, resolve, reject);
           }
 
           console.log('failed post', url, json);
@@ -101,14 +87,7 @@ export class RestService {
         } else {
           const promise = this.redirectRecurse(url, json, contentType, accept, response, this.put, redirectCount + 1);
           if (promise) {
-            promise.then((result) => {
-              resolve(result);
-            })
-            .catch ((err) => {
-              reject(err);
-            });
-
-            return promise;
+            return this.resolveRedirectPromise(promise, resolve, reject);
           }
 
           console.log('failed put', url, json);
@@ -137,14 +116,7 @@ export class RestService {
         } else {
           const promise = this.redirectRecurse(url, json, contentType, accept, response, this.delete, redirectCount + 1);
           if (promise) {
-            promise.then((result) => {
-              resolve(result);
-            })
-            .catch ((err) => {
-              reject(err);
-            });
-
-            return promise;
+            return this.resolveRedirectPromise(promise, resolve, reject);
           }
 
           // console.log('failed delete', url);
@@ -171,6 +143,17 @@ export class RestService {
     }
 
     return callback(response.headers.location, json, contentType, accept, redirectCount + 1);
+  }
+
+  private resolveRedirectPromise(promise: Promise<any>, resolve: any, reject: any): Promise<any> {
+    promise.then((result) => {
+      resolve(result);
+    })
+    .catch ((err) => {
+      reject(err);
+    });
+
+    return promise;
   }
 
 }


### PR DESCRIPTION
resolves #68 

Perform redirects when receiving HTTP 301 and HTTP 302 status codes. This implements a hard-coded max redirect of 10.
A custom property could be implemented but this is left for a future decision or for a reviewers input.

This adds new parameters to the RestService HTTP functions for performing the redirets. The functions are all made to have the same parameters so that the redirect can pass a consistent callback. Unused parameters, such as `json` in the `get()` method, are ignored.

Logging is added for redirects, when `logLevel` is set to `DEBUG` (case insensitive). An error is printed when max redirects is reached.

When no redirection is requested, the `redirectRecurse()` function returns false so that the caller can continue normal behavior.