### PR TITLE
MODWRKFLOW-19: Add support for the delete workflow end point.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,13 @@ program
   });
 
 program
+  .command('delete <name>')
+  .description('delete workflow by name')
+  .action((name: string) => {
+    modWorkflow.deleteWorkflow(name).then(console.log, console.log);
+  });
+
+program
   .command('run <name>')
   .description('run workflow by name')
   .action((name: string) => {

--- a/src/service/rest.service.ts
+++ b/src/service/rest.service.ts
@@ -17,7 +17,7 @@ export class RestService {
           'X-Okapi-Token': config.get('token'),
           'Content-Type': contentType
         }
-      }, (error: any, response: any, body: any) => {
+      }, (error: any, response: any, body?: any) => {
         if (response && response.statusCode >= 200 && response.statusCode <= 299) {
           resolve(JSON.parse(body));
         } else if (error) {
@@ -41,7 +41,7 @@ export class RestService {
           'X-Okapi-Token': config.get('token'),
           'Content-Type': contentType
         }
-      }, (error: any, response: any, body: any) => {
+      }, (error: any, response: any, body?: any) => {
         if (response && response.statusCode >= 200 && response.statusCode <= 299) {
           resolve(body);
         } else if (error) {
@@ -65,7 +65,7 @@ export class RestService {
           'X-Okapi-Token': config.get('token'),
           'Content-Type': contentType
         }
-      }, (error: any, response: any, body: any) => {
+      }, (error: any, response: any, body?: any) => {
         if (response && response.statusCode >= 200 && response.statusCode <= 299) {
           resolve(body);
         } else if (error) {
@@ -89,14 +89,14 @@ export class RestService {
           'Content-Type': contentType,
           'Accept': accept
         }
-      }, (error: any, response: any, body: any) => {
+      }, (error: any, response: any, body?: any) => {
         if (response && response.statusCode >= 200 && response.statusCode <= 299) {
           resolve(body);
         } else if (error) {
-          // console.log('failed delete', url, error);
+          console.log('failed delete', url, error);
           reject(error);
         } else {
-          // console.log('failed delete', url);
+          console.log('failed delete', url);
           reject(body);
         }
       });

--- a/src/service/workflow.service.ts
+++ b/src/service/workflow.service.ts
@@ -78,6 +78,16 @@ class WorkflowService extends RestService implements Enhancer {
     return Promise.reject(`cannot find workflow at ${path}`);
   }
 
+  public deleteWorkflow(name: string): Promise<any> {
+    const path = `${config.get('wd')}/${name}`;
+    if (fileService.exists(path)) {
+      const json = fileService.read(`${path}/workflow.json`);
+      const workflow = JSON.parse(templateService.template(json));
+      return this.delete(`${config.get('mod-workflow')}/workflows/${workflow.id}/delete`);
+    }
+    return Promise.reject(`cannot find workflow at ${path}`);
+  }
+
   public run(name: string): Promise<any> {
     const path = `${config.get('wd')}/${name}`;
     if (fileService.exists(path)) {


### PR DESCRIPTION
see: [MODWRKFLOW-19](https://folio-org.atlassian.net/browse/MODWRKFLOW-19)

The response bodies must also be optional in the case of an error response. Use the `?:` to make this the case for all of the responses.

The delete should console log the errors to the screen like the other methods do.