### PR TITLE
FW-CLI Release 1.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fw-cli",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "FOLIO Workflow CLI",
   "author": "William Welling <wwelling@library.tamu.edu>",
   "license": "MIT",


### PR DESCRIPTION
This is sufficiently stable for being marked as `1.0.0` release.

If there are objections, this can be changed to `0.0.5` release version.

A release may also be cut from this branch and then the main branch can be updated to `1.0.1` or `0.0.6` depending on the decision made.