### PR TITLE
Add the ability to run the fw without installing it.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "tsc -p .",
     "okapi": "node okapi.js",
     "lint": "tslint -p tsconfig.json",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "echo \"Error: no test specified\" && exit 0",
+    "fw": "node ./bin/index.js"
   },
   "bin": {
     "fw": "bin/index.js"


### PR DESCRIPTION
The script still needs to be built.
This allows for running the fw-cli program directly via yarn or node, such as:
```
  yarn run fw --help
```

This is intended to help reduce the technical overhead by avoiding the need to install `fw` globally.
This also ensures that the version of `fw` being run is the desired version based on the checkout out repository and branch.