### PR TITLE
Only show valid, non-hidden, workflows when listing workflows.

### DIFF
--- a/src/service/file.service.ts
+++ b/src/service/file.service.ts
@@ -46,7 +46,7 @@ class FileService {
   public listDirectories(path: string): string[] {
     if (this.exists(path)) {
       return fs.readdirSync(path).filter((file: string) => {
-        return fs.lstatSync(`${path}/${file}`).isDirectory();
+        return !file.startsWith('.') && fs.lstatSync(`${path}/${file}`).isDirectory() && fs.existsSync(`${path}/${file}/workflow.json`);
       });
     }
 


### PR DESCRIPTION
This operates by checking for the existence of the required `workflow.json` within the directories being listed.

Do not include hidden files/directories (these start with `.`).

## Before

```sh
fw -w
 - .git
 - books-call-number
 - circ-fines
 - configs
 - coral-extract
 - create-notes
 - create-tags
 - duplicate-instance-report
 - e-resource
 - evans-pres-repr
 - example-scripttask-js
 - examples
 - gobi
 - hathitrust
 - hegis-po
 - item-history-update
 - medsci-gps-zone
 - nbs-items-note
 - orcid
 - patron
 - purchase-orders
 - rapid-electronic-monos
 - rapid-electronic-serials
 - rapid-print-monos
 - rapid-print-serials
 - remove-books-from-nbs
 - shelflist-holdings
 - shelflist-items
```

## After
```sh
fw -w
 - books-call-number
 - circ-fines
 - coral-extract
 - create-notes
 - create-tags
 - duplicate-instance-report
 - e-resource
 - evans-pres-repr
 - example-scripttask-js
 - gobi
 - hathitrust
 - hegis-po
 - item-history-update
 - medsci-gps-zone
 - nbs-items-note
 - orcid
 - patron
 - purchase-orders
 - rapid-electronic-monos
 - rapid-electronic-serials
 - rapid-print-monos
 - rapid-print-serials
 - remove-books-from-nbs
 - shelflist-holdings
 - shelflist-items
```