### PR TITLE
Issue 125: Properly handle rejections.

### DIFF
--- a/src/service/okapi.service.ts
+++ b/src/service/okapi.service.ts
@@ -134,7 +134,18 @@ class OkapiService extends RestService {
   public createReferenceData(request: { path: string, config?: string, data: any[] }): Promise<any> {
     return request.data.map((data: any) => {
       return () => this.post(`${config.get('okapi')}/${request.path}`, data);
-    }).reduce((prevPromise, process) => prevPromise.then(() => process()), Promise.resolve());
+    }).reduce((chain, callback) => {
+      return chain.then(() =>
+        callback().then(response => {
+          return response;
+        })
+      );
+    }, Promise.resolve())
+    .catch((error) => {
+      process.exitCode = 2;
+
+      return Promise.reject(error);
+    });
   }
 
   public deleteReferenceData(request: { path: string, config?: string, data: any[] }): Promise<any> {
@@ -143,7 +154,18 @@ class OkapiService extends RestService {
         const id = request.config ? config.get(request.config) : data.id;
         return this.delete(`${config.get('okapi')}/${request.path}/${id}`);
       };
-    }).reduce((prevPromise, process) => prevPromise.then(() => process()), Promise.resolve());
+    }).reduce((chain, callback) => {
+      return chain.then(() =>
+        callback().then(response => {
+          return response;
+        })
+      );
+    }, Promise.resolve())
+    .catch((error) => {
+      process.exitCode = 2;
+
+      return Promise.reject(error);
+    });
   }
 
   public getDiscoveryModules(): Promise<any> {

--- a/src/service/workflow.service.ts
+++ b/src/service/workflow.service.ts
@@ -80,7 +80,18 @@ class WorkflowService extends RestService implements Enhancer {
         () => this.createTriggers(name),
         () => this.createNodes(name),
         () => this.finalize(name)
-      ].reduce((prevPromise, process) => prevPromise.then(() => process()), Promise.resolve());
+      ].reduce((chain, callback) => {
+        return chain.then(() =>
+          callback().then(response => {
+            return response;
+          })
+        );
+      }, Promise.resolve())
+      .catch((error) => {
+        process.exitCode = 2;
+
+        return Promise.reject(error);
+      });
     }
 
     process.exitCode = 2;
@@ -218,7 +229,18 @@ class WorkflowService extends RestService implements Enhancer {
         .map((json: any) => templateService.template(json))
         .map((json: any) => JSON.parse(json))
         .map((data: any) => () => modWorkflow.createTrigger(data))
-        .reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve());
+        .reduce((chain, callback) => {
+          return chain.then(() =>
+            callback().then(response => {
+              return response;
+            })
+          );
+        }, Promise.resolve())
+        .catch((error) => {
+          process.exitCode = 2;
+
+          return Promise.reject(error);
+        });
     }
 
     return Promise.resolve([]);
@@ -235,7 +257,18 @@ class WorkflowService extends RestService implements Enhancer {
 
       return this.sort(nodes)
         .map((data: any) => () => modWorkflow.createNode(data))
-        .reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve());
+        .reduce((chain, callback) => {
+          return chain.then(() =>
+            callback().then(response => {
+              return response;
+            })
+          );
+        }, Promise.resolve())
+        .catch((error) => {
+          process.exitCode = 2;
+
+          return Promise.reject(error);
+        });
     }
 
     process.exitCode = 2;


### PR DESCRIPTION
Resolves #125 

The promises nested inside of a promise is causing rejections to get missed. Resolve the inner promise and catch exceptions.
Handle the exceptions on failure and return the valid responses on success.

It is possible to create a common function, but I chose to treat this as individual fixes to focus on immediate resolution as a hot fix rather than analyzing the code and planning the design to repeat less.

I am open to making it repeat less if that is desired (because it is, generally speaking, good practice anyway).