### PR TITLE
Issue 128: Support checksums, created on date, and updated on date.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,6 @@ build/Release
 node_modules/
 jspm_packages/
 
-# TypeScript v1 declaration files
-typings/
-
 # Optional npm cache directory
 .npm
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ These are some configuration settings with special meaning that are managed dire
 | `wd`               | The working directory that contains the `fw-registry` files (usually either `./fw-registry/` or `./fw-registry/examples`.
 
 
+### Checksum Support
+
+This supports build time checksum that represent the configuration used during the build.
+Most, but not all, configuration fields are used to generate a checksum.
+This allows for verifying that the current configuration exactly matches.
+
+The current configuration checksum may be printed using the `-S` or `--checksum` parameter.
+
+The following configuration fields are excluded when building the checksum:
+  - `accessToken`
+  - `refreshToken`
+  - `token`
+  - `userId`
+  - `wd` (working directory)
+
+
+### Git Hash Support
+
+A **Git** hash may be automatically appended onto **Workflow** versions when building.
+This functionality is not enabled by default and requires the `-g` or `--git` parameter to be passed.
+
+
 ## Running mock FOLIO
 
 Provides mock `/authn/login-with-expiry` and `/user-import`.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "conf": "10.2.0",
     "core-js": "3.38.1",
     "cors": "2.8.5",
+    "crypto-js": "^4.2.0",
     "express": "4.21.0",
     "figlet": "1.7.0",
     "handlebars": "4.7.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,13 @@ program
     console.log(JSON.stringify(config.store, null, 2));
     process.exit();
   })
+  .option('-g, --git', 'attempt to append the git hash to the Workflow version during build from within the wd directory.', () => {
+    modWorkflow.enableGitHash();
+  })
+  .option('-S, --checksum', 'print checksum of current workflow configuration (verify via: jq -cM . config.json | sha256sum).', () => {
+    console.log(`${modWorkflow.checksum()}  ${config?.path}\n`);
+    process.exit();
+  })
   .option('-w, --workflows', 'list workflows', () => {
     for (const workflow of modWorkflow.list()) {
       console.log(` - ${workflow}`);

--- a/src/service/workflow.service.ts
+++ b/src/service/workflow.service.ts
@@ -14,7 +14,10 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+const child_process = require('node:child_process');
 const process = require('node:process');
+
+import sha256 from 'crypto-js/sha256';
 
 import { RestService } from './rest.service';
 import { Enhancer } from './enhancer.interface';
@@ -25,6 +28,38 @@ import { templateService } from './template.service';
 import { defaultService } from './default.service';
 
 class WorkflowService extends RestService implements Enhancer {
+
+  private gitHashVersion = false;
+
+  /**
+   * Use SHA256 in such a way that it matches what can be reproduced through manual hashing.
+   *
+   * This excludes the token data from the checksum.
+   * This excludes the wording directory data 'wd' and user id 'userId'from the checksum.
+   *
+   * This should produce an identical hash to the command:
+   *   ```sh
+   *   jq -cM 'del(.token, .accessToken, .refreshToken, .userId, .wd)' config.json | sha256sum
+   *   ```
+   * Where `config.json` is the configuration file.
+   *
+   * The trailing new line is necessary to produce a consistent valid hash in this manner.
+   *
+   * @return The configration hash string.
+   */
+  public checksum(): string {
+    const data = config.store;
+
+    delete data?.token;
+    delete data?.accessToken;
+    delete data?.refreshToken;
+    delete data?.userId;
+    delete data?.wd;
+
+    const json = JSON.stringify(data) + '\n';
+
+    return sha256(json).toString();
+  }
 
   public createTrigger(extractor: any): Promise<any> {
     return this.post(`${this.getAccess()}/triggers`, extractor);
@@ -75,7 +110,7 @@ class WorkflowService extends RestService implements Enhancer {
     const path = `${config.get('wd')}/${name}`;
 
     if (fileService.exists(path)) {
-      return [
+      const workflow = [
         () => this.setup(name),
         () => this.createTriggers(name),
         () => this.createNodes(name),
@@ -92,6 +127,8 @@ class WorkflowService extends RestService implements Enhancer {
 
         return Promise.reject(error);
       });
+
+      return workflow;
     }
 
     process.exitCode = 2;
@@ -177,6 +214,22 @@ class WorkflowService extends RestService implements Enhancer {
     }
 
     return JSON.stringify(obj);
+  }
+
+  public enableGitHash() {
+    this.gitHashVersion = true;
+  }
+
+  public getGitHash() {
+    const data = config?.store;
+    const wd = data?.wd;
+
+    if (!wd) return false;
+
+    const command = "git rev-parse --short=12 HEAD";
+    const options = { "cwd": wd, encoding: 'utf8' };
+
+    return child_process.execSync(command, options)?.trimEnd();
   }
 
   private script(path: string, obj: any, prop: string): void {
@@ -311,8 +364,21 @@ class WorkflowService extends RestService implements Enhancer {
     if (fileService.exists(path)) {
       const json = fileService.read(path);
       const workflow = templateService.template(json);
+      const parsed = JSON.parse(workflow);
 
-      return this.createWorkflow(JSON.parse(workflow));
+      parsed.checksum = modWorkflow.checksum();
+
+      if (this.gitHashVersion) {
+        const suffix = this.getGitHash();
+
+        if (suffix) {
+          parsed.versionTag += `-${suffix}`;
+        } else {
+          throw new Error("Git hash command returned no results in working directory (wd) path.");
+        }
+      }
+
+      return this.createWorkflow(parsed);
     }
 
     process.exitCode = 2;

--- a/src/typings/crypto-js.d.ts
+++ b/src/typings/crypto-js.d.ts
@@ -1,0 +1,1 @@
+declare module 'crypto-js/sha256';


### PR DESCRIPTION
Resolves #128 .

The checksum represents a build configuration rather than a particular workflow. Exclude specific configuration fields when building the checksum:
  - `accessToken`
  - `refreshToken`
  - `token`
  - `userId`
  - `wd` (working directory)

Bring in `crypto-js` to perform the checksum.

This includes **Git** hash integration that is relative to the `wd`.

Add two new parameters:
  - `-g` / `--git`: Attempt to use the git hash to the workflow version when building.
  - `-S` / `--checksum`: print the current checksum.

The checksum operation is performed in a child process.

Ensure the `typings` file is allowed in the **Git** repository and is used.