### PR TITLE
Issue 131: Fix invalid Cookie structure.

### DIFF
--- a/src/service/rest.service.ts
+++ b/src/service/rest.service.ts
@@ -34,13 +34,9 @@ export class RestService {
     if (!refreshToken?.folioRefreshToken) {
       auth['X-Okapi-Token'] = accessToken?.folioAccessToken;
     } else {
-      const cookie = [];
-
-      for (let key in accessToken) {
-        cookie.push(`${key}=${accessToken[key]}`);
+      if (accessToken?.folioAccessToken) {
+        auth['Cookie'] = `folioAccessToken=${accessToken.folioAccessToken}`;
       }
-
-      auth['Cookie'] = cookie.join(';');
     }
 
     return auth;


### PR DESCRIPTION
Resolves #131.

The parts of the `Cookie` that are valid for `Set-Cookie` are not valid for the `Cookie`.

Do not pass the entire cookie values through.
Instead, only pass the main cookie name and the main cookie value.

see: https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-cookie-header