### PR TITLE
Issue 136: Add support for deploy and redeploy commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ Lookup user.
 fw user diku_admin
 ```
 
-Follow configuration, build, activate and run commands for workflows as described in the [FW Registry Readme](fw-registry/README.md).
+Follow configuration, build, activate, deploy, and redeploy and run commands for workflows as described in the [FW Registry Readme](fw-registry/README.md).

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,20 @@ program
   });
 
 program
+  .command('deploy <name>')
+  .description('Build and activate workflow by name.')
+  .action((name: string) => {
+    modWorkflow.deploy(name).then(logConsole, logConsole);
+  });
+
+program
+  .command('redeploy <name>')
+  .description('Delete, build, and activate workflow by name.')
+  .action((name: string) => {
+    modWorkflow.redeploy(name).then(logConsole, logConsole);
+  });
+
+program
   .command('delete <name>')
   .description('Delete workflow by name.')
   .action((name: string) => {

--- a/src/service/workflow.service.ts
+++ b/src/service/workflow.service.ts
@@ -106,8 +106,12 @@ class WorkflowService extends RestService implements Enhancer {
     return Promise.resolve(`new workflow ${name} scaffold created`);
   }
 
-  public build(name: string): Promise<any> {
+  public build(name: string, header: boolean = false): Promise<any> {
     const path = `${config.get('wd')}/${name}`;
+
+    if (header) {
+      console.log(`\nBuilding Workflow ${name}:`);
+    }
 
     if (fileService.exists(path)) {
       const workflow = [
@@ -136,8 +140,12 @@ class WorkflowService extends RestService implements Enhancer {
     return Promise.reject(`Error: Cannot find workflow at ${path}.`);
   }
 
-  public activate(name: string): Promise<any> {
+  public activate(name: string, header: boolean = false): Promise<any> {
     const path = `${config.get('wd')}/${name}`;
+
+    if (header) {
+      console.log(`\nActivating Workflow ${name}:`);
+    }
 
     if (fileService.exists(path)) {
       const json = fileService.read(`${path}/workflow.json`);
@@ -166,8 +174,49 @@ class WorkflowService extends RestService implements Enhancer {
     return Promise.reject(`Error: Cannot find workflow at ${path}.`);
   }
 
-  public deleteWorkflow(name: string): Promise<any> {
+  public deploy(name: string): Promise<any> {
+    const service = this;
+
+    return service.build(name, true)?.then((result) => {
+      // Ensure the build response is printed.
+      if (result) console.log(result);
+
+      return service.activate(name, true);
+    });
+  }
+
+  public redeploy(name: string): Promise<any> {
+    const service = this;
+
+    const buildActivate = () => {
+      return service.build(name, true)?.then((result) => {
+        // Ensure the build response is printed.
+        if (result) console.log(result);
+
+        return service.activate(name, true);
+      });
+    }
+
+    return service.deleteWorkflow(name, true)?.then((result) => {
+      // Ensure the delete response is printed.
+      if (result) console.log(result);
+
+      return buildActivate();
+    }).catch(error => {
+      if (error?.http?.code === 404) {
+        console.log(`\nWorkflow ${name} does not exist, continuing on.`);
+      }
+
+      return buildActivate();
+    });
+  }
+
+  public deleteWorkflow(name: string, header: boolean = false): Promise<any> {
     const path = `${config.get('wd')}/${name}`;
+
+    if (header) {
+      console.log(`\nDeleting Workflow ${name}:`);
+    }
 
     if (fileService.exists(path)) {
       const json = fileService.read(`${path}/workflow.json`);


### PR DESCRIPTION
Resolves #136 .

This introduced no new significant code.
The new code introduced just calls the existing `delete`, `build`, and `activate` commands.

A `deploy` shall `build` and `activate`.
A `redeploy` shall `delete`, `build`, and `activate`.

A `404` on delete is considered not an error and the process continues on for `redeploy`.

Add logging to each of the `delete`, `build`, and `activate` commands via a new optional parameter. This allows for the `deploy` and `redeploy` to print messages to help identify where each request is. The parameter defaults to `false` to preserve existing behavior.


## Example Help Information

The following is what `fw-cli --help` shows for the new commands:
```
  deploy <name>                            Build and activate workflow by name.
  redeploy <name>                          Delete, build, and activate workflow by name.
```

## Example Redeploy Behavior

For when `redeploy` is used and there is no existing workflow to delete, then the delete error is ignored and the following snippet is printed:
```

Deleting Workflow patron:

Workflow patron does not exist, continuing on.

Building Workflow patron:
{
...
```


## Example Deploy Behavior

Forn when `deploy` is used and there is an existing workflow, then the following error is presented and `activate` is not attempted:

```

Building Workflow patron:
{
  status: 'Error: Failed to POST.',
...
  http: { code: 409, message: '' },
  error: {
    errors: [
      {
        message: "The workflow cannot be created because a workflow with UUID 'df9d9b70-665a-11eb-b9fd-afcd4d476de5' and Version Tag '1.0' already exists.",
        type: 'WorkflowCreateAlreadyExistsException',
        code: '409 CONFLICT',
        parameters: []
      }
    ],
    total_records: 1
  }
}
```