### PR TITLE
Issue 136: Redeploy should not incorrectly return non-zero on success.

### DIFF
--- a/src/service/workflow.service.ts
+++ b/src/service/workflow.service.ts
@@ -205,6 +205,9 @@ class WorkflowService extends RestService implements Enhancer {
     }).catch(error => {
       if (error?.http?.code === 404) {
         console.log(`\nWorkflow ${name} does not exist, continuing on.`);
+
+        // Reset the console error to avoid incorrectly return with error code on success.
+        process.exitCode = 0;
       }
 
       return buildActivate();


### PR DESCRIPTION
Further resolves #136 .

The `service.deleteWorkflow()` call automatically sets the return status code to `2` on failure. In the case of redeploy, a `404` is not considered a failure.

The `redeploy` command will continue on, but the return status code is still set to `2`! The program the exits with `2` when returning a success.

Explicitly reset the resturn code to `0` when a `404` is received by the `delete` during a `redeploy`. This ensures a proper return code of `0` for cases when the `delete` returns a `404` only.

A proper error return code will still happen if any other part of the process fails.