### PR TITLE
Issue 140: Refactor variables and structures for Eureka changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,23 @@ fw
 
 These are some configuration settings with special meaning that are managed directly by `fw-cli`.
 
-| Setting            | Description
-| ------------------ | -----------
-| `access`           | Used to toggle between the **OKAPI** URL and the `mod-workflow` URL (Set to either `okapi` or `mod-workflow`).
-| `accessToken`      | The **FOLIO Access Token** cookie, or `X-Okapi-Token` (in both cases, `folioAccessToken` contains the token).
-| `okapi`            | The **OKAPI** URL to use.
-| `okapiLoginPath`   | The login path to use (for classic, use `/authn/login`; for RTR, use `/authn/login-with-expiry`).
-| `mod-workflow`     | The `mod-workflow` URL.
-| `password`         | The pass to use for logging into **OKAPI**.
-| `refreshToken`     | The **FOLIO Refresh Token** cookie (`folioRefreshToken` contains the refresh token).
-| `tenant`           | The `tenant` to use for logging into and interacting with **OKAPI** or `mod-workflow`.
-| `token`            | The `X-Okapi-Token` or the `accessToken.folioAccessToken` string.
-| `username`         | The user to use for logging into **OKAPI**.
-| `userId`           | The **User ID** retrieved from the last `user` command call.
-| `wd`               | The working directory that contains the `fw-registry` files (usually either `./fw-registry/` or `./fw-registry/examples`.
+| Setting                | Description
+| ---------------------- | -----------
+| `cliAccess`            | For CLI only; Used to toggle between the `gateway` **URL** and the `direct` **URL** (`direct` is generally a local `mod-workflow` instance).
+| `cliDirectUrl`         | For CLI only; The **URL** to use when `cliAccess` is set to `direct`.
+| `cliFolioAccessToken`  | For CLI only; The `folioAccessToken` cookie value.
+| `cliFolioLoginPath`    | For CLI only; The login path to use (`/authn/login-with-expiry`).
+| `cliFolioPass`         | For CLI only; The pass to use for logging into the gateway.
+| `cliFolioRefreshToken` | For CLI only; The `folioRefreshToken` cookie value.
+| `cliFolioTenant`       | For CLI only; The `tenant` to use for logging into or interacting with the gateway.
+| `cliFolioToken`        | For CLI only; The `folioAccessToken` as the `token` **HTTP** header value, for compatibility purposes.
+| `cliFolioUser`         | For CLI only; The user name to use for logging into the gateway.
+| `cliGatewayUrl`        | For CLI only; The **URL** to use when `cliAccess` is set to `gateway`.
+| `cliUserId`            | For CLI only; The **User ID** retrieved from the last `user` command call.
+| `cliWd`                | For CLI only; The working directory that contains the `fw-registry` files (usually either `./fw-registry/` or `./fw-registry/examples`.
+| `folioPass`            | (deprecated, use **FolioRequestTask** instead of **RequestTask** and this is not needed) The pass to use for logging into the gateway in a built node.
+| `folioUser`            | (deprecated, use **FolioRequestTask** instead of **RequestTask** and this is not needed) The user name to use for logging into the gateway in a built node.
+| `gatewayUrl`           | The gateway **URL** that gets embedded into each built node.
 
 
 ### Checksum Support
@@ -46,14 +49,18 @@ This allows for verifying that the current configuration exactly matches.
 The current configuration checksum may be printed using the `-S` or `--checksum` parameter.
 
 The following configuration fields are excluded when building the checksum:
-  - `access`
-  - `accessToken`
-  - `mod-camunda`
-  - `mod-workflow`
-  - `refreshToken`
-  - `token`
-  - `userId`
-  - `wd` (working directory)
+  - `cliAccess`
+  - `cliDirectUrl`
+  - `cliFolioAccessToken`
+  - `cliFolioLoginPath`
+  - `cliFolioPass`
+  - `cliFolioRefreshToken`
+  - `cliFolioTenant`
+  - `cliFolioToken`
+  - `cliFolioUser`
+  - `cliGatewayUrl`
+  - `cliUserId`
+  - `cliWd`
 
 
 ### Git Hash Support

--- a/gateway.js
+++ b/gateway.js
@@ -69,5 +69,5 @@ server.post('/user-import', function (req, res) {
 });
 
 server.listen(PORT, HOST, () => {
-  console.log(`Mock Okapi server listening on http://${HOST}:${PORT}${BASE_HREF}`);
+  console.log(`Mock Gateway server listening on http://${HOST}:${PORT}${BASE_HREF}`);
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc -p .",
-    "okapi": "node okapi.js",
+    "gateway": "node gateway.js",
     "lint": "tslint -p tsconfig.json",
     "test": "echo \"Error: no test specified\" && exit 0",
     "fw": "node ./bin/index.js"

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,54 +18,66 @@ const Conf = require('conf');
 
 // tslint:disable: object-literal-key-quotes
 const schema = {
-  access: {
+  cliAccess: {
     type: 'string',
-    enum: ['okapi', 'mod-workflow'],
-    default: 'mod-workflow',
+    enum: ['gateway', 'direct'],
+    default: 'gateway',
   },
-  accessToken: {
-    type: 'object',
-    default: {},
-  },
-  okapi: {
-    type: 'string',
-    default: 'http://localhost:9130',
-  },
-  okapiLoginPath: {
-    type: 'string',
-    default: '/authn/login-with-expiry',
-  },
-  'mod-workflow': {
+  cliDirectUrl: {
     type: 'string',
     default: 'http://localhost:9001',
   },
-  password: {
-    type: 'string',
-    default: 'admin',
-  },
-  refreshToken: {
+  cliFolioAccessToken: {
     type: 'object',
     default: {},
   },
-  tenant: {
+  cliFolioLoginPath: {
+    type: 'string',
+    default: '/authn/login-with-expiry',
+  },
+  cliFolioPass: {
+    type: 'string',
+    default: 'admin',
+  },
+  cliFolioRefreshToken: {
+    type: 'object',
+    default: {},
+  },
+  cliFolioTenant: {
     type: 'string',
     default: 'diku'
   },
-  token: {
+  cliFolioToken: {
     type: 'string',
     default: '',
   },
-  username: {
+  cliFolioUser: {
     type: 'string',
     default: 'diku_admin',
   },
-  userId: {
+  cliGatewayUrl: {
+    type: 'string',
+    default: 'http://localhost:9130',
+  },
+  cliUserId: {
     type: 'string',
     default: '',
   },
-  wd: {
+  cliWd: {
     type: 'string',
     default: './fw-registry',
+  },
+  folioPass: {
+    type: 'string',
+    default: '',
+  },
+  folioUser: {
+    type: 'string',
+    default: '',
+  },
+  gatewayUrl: {
+    type: 'string',
+    default: 'http://localhost:9130',
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ const figlet = require('figlet');
 const process = require('node:process');
 const program = require('commander');
 
-import { okapi } from './service/okapi.service';
+import { gateway } from './service/gateway.service';
 import { config } from './config';
 import { modWorkflow } from './service/workflow.service';
 import { fileService } from './service/file.service';
@@ -56,7 +56,7 @@ program
     console.log(JSON.stringify(config.store, null, 2));
     process.exit();
   })
-  .option('-g, --git', 'attempt to append the git hash to the Workflow version during build from within the wd directory.', () => {
+  .option('-g, --git', 'attempt to append the git hash to the Workflow version during build from within the cliWd directory.', () => {
     modWorkflow.enableGitHash();
   })
   .option('-S, --checksum', 'print checksum of current workflow configuration (verify via: jq -cM . config.json | sha256sum).', () => {
@@ -155,16 +155,17 @@ program
   .command('login [username] [password]')
   .description('Login to acquire authentication tokens.')
   .action((username?: string, password?: string) => {
-    okapi.login(username, password).then(logConsole, logConsole);
+    gateway.login(username, password).then(logConsole, logConsole);
   });
 
 program
   .command('logout')
   .description('Logout to remove authentication tokens.')
   .action(() => {
-    config.delete('token');
-    config.delete('accessToken');
-    config.delete('refreshToken');
+    config.delete('cliFolioAccessToken');
+    config.delete('cliFolioRefreshToken');
+    config.delete('cliFolioToken');
+
     console.log('success');
   });
 
@@ -172,14 +173,14 @@ program
   .command('user [username]')
   .description('Lookup user.')
   .action((username?: string) => {
-    okapi.getUser(username).then(logConsole, logConsole);
+    gateway.getUser(username).then(logConsole, logConsole);
   });
 
 program
   .command('lookup <module>')
   .description('Lookup module, matching name starting with.')
   .action((name: string) => {
-    okapi.getDiscoveryModuleURL(name).then(logConsole, logConsole);
+    gateway.getDiscoveryModuleURL(name).then(logConsole, logConsole);
   });
 
 program
@@ -193,7 +194,7 @@ program
   .command('add <workflow> <type> <name>')
   .description('Add new processor with name to an existing workflow.')
   .action((workflow: string, type: 'processor', name: string) => {
-    const workflowPath = `${config.get('wd')}/${workflow}`;
+    const workflowPath = `${modWorkflow.getWd()}${workflow}`;
 
     if (fileService.exists(workflowPath)) {
       switch (type) {

--- a/src/service/gateway.service.ts
+++ b/src/service/gateway.service.ts
@@ -21,18 +21,18 @@ import { RestService } from './rest.service';
 
 class OkapiService extends RestService {
 
-  public login(username: string = config.get('username'), password: string = config.get('password')): Promise<any> {
-    config.delete('token');
-    config.delete('accessToken');
-    config.delete('refreshToken');
+  public login(username: string = config.get('cliFolioUser'), password: string = config.get('cliFolioPass')): Promise<any> {
+    config.delete('cliFolioToken');
+    config.delete('cliFolioAccessToken');
+    config.delete('cliFolioRefreshToken');
 
     return new Promise((resolve, reject) => {
       this.request({
-        url: `${config.get('okapi')}${config.get('okapiLoginPath')}`,
+        url: `${config.get('cliGatewayUrl')}${config.get('cliFolioLoginPath')}`,
         json: { username, password },
         method: 'POST',
         headers: {
-          'X-Okapi-Tenant': config.get('tenant'),
+          'X-Okapi-Tenant': config.get('cliFolioTenant'),
           'Content-Type': 'application/json',
           'Accept': 'application/json'
         }
@@ -70,11 +70,11 @@ class OkapiService extends RestService {
           // The `accessToken` and `refreshToken` provide complete objects to use on HTTP requests.
           // If the `refreshToken` is an empty Object, then this must be a non-RTR access, so `accessToken.folioAccessToken` represents the `X-Okapi-Token`.
           if (!!accessToken?.folioAccessToken) {
-            config.set('token', accessToken.folioAccessToken);
-            config.set('accessToken', accessToken);
+            config.set('cliFolioToken', accessToken.folioAccessToken);
+            config.set('cliFolioAccessToken', accessToken);
 
             if (!!refreshToken?.folioRefreshToken) {
-              config.set('refreshToken', refreshToken);
+              config.set('cliFolioRefreshToken', refreshToken);
             }
 
             resolve({
@@ -100,7 +100,7 @@ class OkapiService extends RestService {
   }
 
   public getUser(username: string = config.get('username')): Promise<any> {
-    const url = `${config.get('okapi')}/users?query=username==${username}`;
+    const url = `${config.get('cliGatewayUrl')}/users?query=username==${username}`;
 
     return new Promise((resolve, reject) => {
       this.request({
@@ -109,7 +109,7 @@ class OkapiService extends RestService {
         headers: {
           'Accept': ['application/json', 'text/plain'],
           'Content-Type': 'application/json',
-          'X-Okapi-Tenant': config.get('tenant'),
+          'X-Okapi-Tenant': config.get('cliFolioTenant'),
           ...this.buildAccessHeaders(),
         }
       }, (error: any, resp: any, body: any) => {
@@ -118,7 +118,7 @@ class OkapiService extends RestService {
 
           if (users?.length > 0) {
             const user = users[0]
-            config.set('userId', user.id);
+            config.set('cliUserId', user.id);
 
             resolve(user);
           } else {
@@ -133,7 +133,7 @@ class OkapiService extends RestService {
 
   public createReferenceData(request: { path: string, config?: string, data: any[] }): Promise<any> {
     return request.data.map((data: any) => {
-      return () => this.post(`${config.get('okapi')}/${request.path}`, data);
+      return () => this.post(`${config.get('cliGatewayUrl')}/${request.path}`, data);
     }).reduce((chain, callback) => {
       return chain.then(() =>
         callback().then(response => {
@@ -152,7 +152,7 @@ class OkapiService extends RestService {
     return request.data.map((data: any) => {
       return () => {
         const id = request.config ? config.get(request.config) : data.id;
-        return this.delete(`${config.get('okapi')}/${request.path}/${id}`);
+        return this.delete(`${config.get('cliGatewayUrl')}/${request.path}/${id}`);
       };
     }).reduce((chain, callback) => {
       return chain.then(() =>
@@ -169,12 +169,12 @@ class OkapiService extends RestService {
   }
 
   public getDiscoveryModules(): Promise<any> {
-    return this.get(`${config.get('okapi')}/_/discovery/modules`);
+    return this.get(`${config.get('cliGatewayUrl')}/_/discovery/modules`);
   }
 
   public getDiscoveryModuleURL(name: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      this.get(`${config.get('okapi')}/_/discovery/modules`).then((modules: any[]) => {
+      this.get(`${config.get('cliGatewayUrl')}/_/discovery/modules`).then((modules: any[]) => {
         for (const module of modules) {
           if (module.srvcId.startsWith(name) || module.srvcId.startsWith(`mod-${name}`)) {
             resolve(module.url);
@@ -200,7 +200,7 @@ class OkapiService extends RestService {
    */
   protected loginError(user: string, reject: any, body: any, resp?: any) {
     this.serviceError(`Login failed for user '${user}'.`,
-      `${config.get('okapi')}${config.get('okapiLoginPath')}`,
+      `${config.get('cliGatewayUrl')}${config.get('cliFolioLoginPath')}`,
       reject,
       body,
       null,
@@ -236,4 +236,4 @@ class OkapiService extends RestService {
 
 }
 
-export const okapi = new OkapiService();
+export const gateway = new OkapiService();

--- a/src/service/rest.service.ts
+++ b/src/service/rest.service.ts
@@ -28,8 +28,8 @@ export class RestService {
    */
   public buildAccessHeaders(): Record<string, any> {
     const auth: Record<string, any> = {};
-    const accessToken: Record<string, any> = config.get('accessToken');
-    const refreshToken: Record<string, any> = config.get('refreshToken');
+    const accessToken: Record<string, any> = config.get('cliFolioAccessToken');
+    const refreshToken: Record<string, any> = config.get('cliFolioRefreshToken');
 
     if (!refreshToken?.folioRefreshToken) {
       auth['X-Okapi-Token'] = accessToken?.folioAccessToken;
@@ -59,7 +59,7 @@ export class RestService {
         url,
         headers: {
           'Content-Type': contentType,
-          'X-Okapi-Tenant': config.get('tenant'),
+          'X-Okapi-Tenant': config.get('cliFolioTenant'),
           ...this.buildAccessHeaders(),
         }
       }, (error: any, resp?: any, body?: any) => {
@@ -79,7 +79,7 @@ export class RestService {
         json,
         headers: {
           'Content-Type': contentType,
-          'X-Okapi-Tenant': config.get('tenant'),
+          'X-Okapi-Tenant': config.get('cliFolioTenant'),
           ...this.buildAccessHeaders(),
         }
       }, (error: any, resp?: any, body?: any) => {
@@ -99,7 +99,7 @@ export class RestService {
         json,
         headers: {
           'Content-Type': contentType,
-          'X-Okapi-Tenant': config.get('tenant'),
+          'X-Okapi-Tenant': config.get('cliFolioTenant'),
           ...this.buildAccessHeaders(),
         }
       }, (error: any, resp: any, body?: any) => {
@@ -119,12 +119,12 @@ export class RestService {
         headers: {
           'Accept': accept,
           'Content-Type': contentType,
-          'X-Okapi-Tenant': config.get('tenant'),
+          'X-Okapi-Tenant': config.get('cliFolioTenant'),
           ...this.buildAccessHeaders(),
         }
       }, (error: any, resp?: any, body?: any) => {
         if (!!resp && resp?.statusCode >= 200 && resp?.statusCode <= 299) {
-          console.log('Delete succeeded.', url);
+          console.log("Delete succeeded.\n", url);
           resolve(body);
         } else {
           this.serviceError('Error: Failed to DELETE.', url, reject, body, error, resp);

--- a/src/service/workflow.service.ts
+++ b/src/service/workflow.service.ts
@@ -34,12 +34,11 @@ class WorkflowService extends RestService implements Enhancer {
   /**
    * Use SHA256 in such a way that it matches what can be reproduced through manual hashing.
    *
-   * This excludes the token data from the checksum.
-   * This excludes the wording directory data 'wd' and user id 'userId'from the checksum.
+   * This excludes all **CLI** specific variables.
    *
    * This should produce an identical hash to the command:
    *   ```sh
-   *   jq --sort-keys -cM 'del(.access, .accessToken, ."mod-camunda", ."mod-workflow", .refreshToken, .token, .userId, .wd)' config.json | sha256sum
+   *   jq --sort-keys -cM 'del(.cliAccess, .cliDirectUrl, .cliFolioAccessToken, .cliFolioLoginPath, .cliFolioPass, .cliFolioRefreshToken, .cliFolioTenant, .cliFolioToken, .cliFolioUser, .cliGatewayUrl, .cliUserId, .cliWd)' config.json | sha256sum
    *   ```
    * Where `config.json` is the configuration file.
    *
@@ -49,14 +48,18 @@ class WorkflowService extends RestService implements Enhancer {
    */
   public checksum(): string {
     const toDelete = [
-      'access',
-      'accessToken',
-      'mod-camunda',
-      'mod-workflow',
-      'refreshToken',
-      'token',
-      'userId',
-      'wd'
+      'cliAccess',
+      'cliDirectUrl',
+      'cliFolioAccessToken',
+      'cliFolioLoginPath',
+      'cliFolioPass',
+      'cliFolioRefreshToken',
+      'cliFolioTenant',
+      'cliFolioToken',
+      'cliFolioUser',
+      'cliGatewayUrl',
+      'cliUserId',
+      'cliWd`'
     ];
 
     const json = JSON.stringify(
@@ -71,19 +74,19 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   public createTrigger(extractor: any): Promise<any> {
-    return this.post(`${this.getAccess()}/triggers`, extractor);
+    return this.post(`${this.getAccessUrl()}/triggers`, extractor);
   }
 
   public createNode(node: any): Promise<any> {
-    return this.post(`${this.getAccess()}/nodes`, node);
+    return this.post(`${this.getAccessUrl()}/nodes`, node);
   }
 
   public createWorkflow(workflow: any): Promise<any> {
-    return this.post(`${this.getAccess()}/workflows`, workflow);
+    return this.post(`${this.getAccessUrl()}/workflows`, workflow);
   }
 
   public list(): string[] {
-    const path = `${config.get('wd')}`;
+    const path = this.getWd();
 
     if (fileService.exists(path)) {
       return fileService.listDirectories(path);
@@ -95,7 +98,7 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   public scaffold(name: string): Promise<any> {
-    const path = `${config.get('wd')}/${name}`;
+    const path = `${this.getWd()}${name}`;
     if (fileService.exists(path)) {
       process.exitCode = 2;
 
@@ -116,7 +119,7 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   public build(name: string, header: boolean = false): Promise<any> {
-    const path = `${config.get('wd')}/${name}`;
+    const path = `${this.getWd()}${name}`;
 
     if (header) {
       console.log(`\nBuilding Workflow ${name}:`);
@@ -150,7 +153,7 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   public activate(name: string, header: boolean = false): Promise<any> {
-    const path = `${config.get('wd')}/${name}`;
+    const path = `${this.getWd()}${name}`;
 
     if (header) {
       console.log(`\nActivating Workflow ${name}:`);
@@ -160,7 +163,7 @@ class WorkflowService extends RestService implements Enhancer {
       const json = fileService.read(`${path}/workflow.json`);
       const workflow = JSON.parse(templateService.template(json));
 
-      return this.put(`${this.getAccess()}/workflows/${workflow.id}/activate`, {});
+      return this.put(`${this.getAccessUrl()}/workflows/${workflow.id}/activate`, {});
     }
 
     process.exitCode = 2;
@@ -169,13 +172,13 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   public deactivate(name: string): Promise<any> {
-    const path = `${config.get('wd')}/${name}`;
+    const path = `${this.getWd()}${name}`;
 
     if (fileService.exists(path)) {
       const json = fileService.read(`${path}/workflow.json`);
       const workflow = JSON.parse(templateService.template(json));
 
-      return this.put(`${this.getAccess()}/workflows/${workflow.id}/deactivate`, {});
+      return this.put(`${this.getAccessUrl()}/workflows/${workflow.id}/deactivate`, {});
     }
 
     process.exitCode = 2;
@@ -227,7 +230,7 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   public deleteWorkflow(name: string, header: boolean = false): Promise<any> {
-    const path = `${config.get('wd')}/${name}`;
+    const path = `${this.getWd()}${name}`;
 
     if (header) {
       console.log(`\nDeleting Workflow ${name}:`);
@@ -237,7 +240,7 @@ class WorkflowService extends RestService implements Enhancer {
       const json = fileService.read(`${path}/workflow.json`);
       const workflow = JSON.parse(templateService.template(json));
 
-      return this.delete(`${this.getAccess()}/workflows/${workflow.id}/delete`);
+      return this.delete(`${this.getAccessUrl()}/workflows/${workflow.id}/delete`);
     }
 
     process.exitCode = 2;
@@ -246,13 +249,13 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   public run(name: string): Promise<any> {
-    const path = `${config.get('wd')}/${name}`;
+    const path = `${this.getWd()}${name}`;
 
     if (fileService.exists(path)) {
       const json = fileService.read(`${path}/workflow.json`);
       const workflow = JSON.parse(templateService.template(json));
 
-      return this.post(`${this.getAccess()}/workflows/${workflow.id}/start`, {});
+      return this.post(`${this.getAccessUrl()}/workflows/${workflow.id}/start`, {});
     }
 
     process.exitCode = 2;
@@ -286,14 +289,33 @@ class WorkflowService extends RestService implements Enhancer {
 
   public getGitHash() {
     const data = config?.store;
-    const wd = data?.wd;
+    const cliWd = data?.cliWd;
 
-    if (!wd) return false;
+    if (!cliWd) return false;
 
     const command = "git rev-parse --short=12 HEAD";
-    const options = { "cwd": wd, encoding: 'utf8' };
+    const options = { "cwd": cliWd, encoding: 'utf8' };
 
     return child_process.execSync(command, options)?.trimEnd();
+  }
+
+  /**
+   * Get the CLI working directory.
+   *
+   * This ensures a trailing slash always exists.
+   *
+   * @return The working directory with a trailing slash.
+   */
+  public getWd(): string {
+    let wd = config.get('cliWd');
+
+    if (typeof wd != 'string') {
+      wd = '';
+    }
+
+    if (wd == '') return './';
+
+    return wd.replace(/\/*$/, '/');
   }
 
   private script(path: string, obj: any, prop: string): void {
@@ -323,7 +345,7 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   private setup(name: string): Promise<any> {
-    const path = `${config.get('wd')}/${name}/setup.json`;
+    const path = `${this.getWd()}${name}/setup.json`;
 
     if (fileService.exists(path)) {
       const setup = JSON.parse(fileService.read(path));
@@ -338,7 +360,7 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   private createTriggers(name: string): Promise<any> {
-    const path = `${config.get('wd')}/${name}/triggers`;
+    const path = `${this.getWd()}${name}/triggers`;
 
     if (fileService.exists(path)) {
       return fileService.readAll(path, '.json')
@@ -364,7 +386,7 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   private createNodes(name: string): Promise<any> {
-    const path = `${config.get('wd')}/${name}/nodes`;
+    const path = `${this.getWd()}${name}/nodes`;
 
     if (fileService.exists(path)) {
       const nodes = fileService.readAll(path, '.json')
@@ -423,7 +445,7 @@ class WorkflowService extends RestService implements Enhancer {
   }
 
   private finalize(name: string): Promise<any> {
-    const path = `${config.get('wd')}/${name}/workflow.json`;
+    const path = `${this.getWd()}${name}/workflow.json`;
 
     if (fileService.exists(path)) {
       const json = fileService.read(path);
@@ -438,7 +460,7 @@ class WorkflowService extends RestService implements Enhancer {
         if (suffix) {
           parsed.versionTag += `-${suffix}`;
         } else {
-          throw new Error("Git hash command returned no results in working directory (wd) path.");
+          throw new Error("Git hash command returned no results in working directory (cliWd) path.");
         }
       }
 
@@ -450,10 +472,14 @@ class WorkflowService extends RestService implements Enhancer {
     return Promise.reject(`Error: Cannot find workflow.json at ${path}.`);
   }
 
-  private getAccess(): string {
-    const access = config.get('access');
+  private getAccessUrl(): string {
+    const access = config.get('cliAccess');
 
-    return config.get(access);
+    if (access == 'direct') {
+      return config.get('cliDirectUrl');
+    }
+
+    return config.get('cliGatewayUrl');
   }
 
 }


### PR DESCRIPTION
## Purpose

resolves #140


## Details

Make the **CLI** related configuration variables explicitly clear by prefixing them with `cli`.

Remove all unnecessary configuration variables.

The `getAccess()`, now called `getAccessUrl()`, properly returns a **URL**.

The `access` is now `cliAccess` and it accepts wither `direct` (in place of `mod-workflow`) and `gateway` (in place of `okapi`).

The tokens now have `folio` prefixed to them.
For example, `accessToken` is now `cliFolioAccessToken` (with cli also prefixed as noted above).

The following non-cli variables are renamed:
  - `username` is now `folioUser`.
  - `password` is now `folioPass`.
  - `okapi-url` is now `gatewayUrl`.

Note that `folioUser` and `folioPass` are slated for removal (deprecated) once the `fw-registry` files are all updated to utilize the `FolioRequestDelegate` instead of `RequestDelegate`.

The `tenant` is now removed.
The `okapiLoginPath` is now removed.

The `okapi` is now `cliGatewayUrl`.
There is now a `cliFolioLoginPath`.

Rename the `okapi.serverice.ts` to `gateway.service.ts`.

Ensure that the `cliWd` always has a trailing slash. Empty strings for `cliWd` will use explicit relative directory of `./`.

The `tenant` appears to not be needed for `fw-registry`.
This means that `cliFolioTenant` now provides the `fw-cli` necessities of the tenant.

Update the check sum generation.

Update the read me documentation.