### PR TITLE
Issue 144: Use cache file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,29 @@ fw
 
 These are some configuration settings with special meaning that are managed directly by `fw-cli`.
 
+| Setting             | Description
+| ------------------- | -----------
+| `cliAccess`         | For CLI only; Used to toggle between the `gateway` **URL** and the `direct` **URL** (`direct` is generally a local `mod-workflow` instance).
+| `cliDirectUrl`      | For CLI only; The **URL** to use when `cliAccess` is set to `direct`.
+| `cliFolioLoginPath` | For CLI only; The login path to use (`/authn/login-with-expiry`).
+| `cliFolioPass`      | For CLI only; The pass to use for logging into the gateway.
+| `cliFolioTenant`    | For CLI only; The `tenant` to use for logging into or interacting with the gateway.
+| `cliFolioUser`      | For CLI only; The user name to use for logging into the gateway.
+| `cliGatewayUrl`     | For CLI only; The **URL** to use when `cliAccess` is set to `gateway`.
+| `cliWd`             | For CLI only; The working directory that contains the `fw-registry` files (usually either `./fw-registry/` or `./fw-registry/examples`.
+| `folioPass`         | (deprecated, use **FolioRequestTask** instead of **RequestTask** and this is not needed) The pass to use for logging into the gateway in a built node.
+| `folioUser`         | (deprecated, use **FolioRequestTask** instead of **RequestTask** and this is not needed) The user name to use for logging into the gateway in a built node.
+| `gatewayUrl`        | The gateway **URL** that gets embedded into each built node.
+
+
+The following are now `cache` rather than `config`.
+
 | Setting                | Description
 | ---------------------- | -----------
-| `cliAccess`            | For CLI only; Used to toggle between the `gateway` **URL** and the `direct` **URL** (`direct` is generally a local `mod-workflow` instance).
-| `cliDirectUrl`         | For CLI only; The **URL** to use when `cliAccess` is set to `direct`.
 | `cliFolioAccessToken`  | For CLI only; The `folioAccessToken` cookie value.
-| `cliFolioLoginPath`    | For CLI only; The login path to use (`/authn/login-with-expiry`).
-| `cliFolioPass`         | For CLI only; The pass to use for logging into the gateway.
 | `cliFolioRefreshToken` | For CLI only; The `folioRefreshToken` cookie value.
-| `cliFolioTenant`       | For CLI only; The `tenant` to use for logging into or interacting with the gateway.
 | `cliFolioToken`        | For CLI only; The `folioAccessToken` as the `token` **HTTP** header value, for compatibility purposes.
-| `cliFolioUser`         | For CLI only; The user name to use for logging into the gateway.
-| `cliGatewayUrl`        | For CLI only; The **URL** to use when `cliAccess` is set to `gateway`.
 | `cliUserId`            | For CLI only; The **User ID** retrieved from the last `user` command call.
-| `cliWd`                | For CLI only; The working directory that contains the `fw-registry` files (usually either `./fw-registry/` or `./fw-registry/examples`.
-| `folioPass`            | (deprecated, use **FolioRequestTask** instead of **RequestTask** and this is not needed) The pass to use for logging into the gateway in a built node.
-| `folioUser`            | (deprecated, use **FolioRequestTask** instead of **RequestTask** and this is not needed) The user name to use for logging into the gateway in a built node.
-| `gatewayUrl`           | The gateway **URL** that gets embedded into each built node.
 
 
 ### Checksum Support

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -17,56 +17,28 @@
 const Conf = require('conf');
 
 const schema = {
-  cliAccess: {
-    type: 'string',
-    enum: ['gateway', 'direct'],
-    default: 'gateway',
+  cliFolioAccessToken: {
+    type: 'object',
+    default: {},
   },
-  cliDirectUrl: {
-    type: 'string',
-    default: 'http://localhost:9001',
+  cliFolioRefreshToken: {
+    type: 'object',
+    default: {},
   },
-  cliFolioLoginPath: {
-    type: 'string',
-    default: '/authn/login-with-expiry',
-  },
-  cliFolioPass: {
-    type: 'string',
-    default: 'admin',
-  },
-  cliFolioTenant: {
-    type: 'string',
-    default: 'diku'
-  },
-  cliFolioUser: {
-    type: 'string',
-    default: 'diku_admin',
-  },
-  cliGatewayUrl: {
-    type: 'string',
-    default: 'http://localhost:9130',
-  },
-  cliWd: {
-    type: 'string',
-    default: './fw-registry',
-  },
-  folioPass: {
+  cliFolioToken: {
     type: 'string',
     default: '',
   },
-  folioUser: {
+  cliUserId: {
     type: 'string',
     default: '',
   },
-  gatewayUrl: {
-    type: 'string',
-    default: 'http://localhost:9130',
-  }
 };
 
 export const projectName = 'fwcli';
 
-export const config = new Conf({
+export const cache = new Conf({
+  configName: 'cache',
   projectName,
-  schema
+  schema,
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ const process = require('node:process');
 const program = require('commander');
 
 import { gateway } from './service/gateway.service';
+import { cache } from './cache';
 import { config } from './config';
 import { modWorkflow } from './service/workflow.service';
 import { fileService } from './service/file.service';
@@ -41,7 +42,7 @@ if (!fileService.exists(CONF_DIR)) {
  * @param value The string or object to log to the console.
  */
 function logConsole(value: any) {
-  if (typeof value == 'string') {
+  if (typeof value === 'string') {
     console.log(value);
   } else {
     console.dir(value, { depth: null, colors: true });
@@ -54,6 +55,10 @@ program
   .allowUnknownOption(false)
   .option('-c, --config', 'show current configuration', () => {
     console.log(JSON.stringify(config.store, null, 2));
+    process.exit();
+  })
+  .option('-C, --cache', 'show current cache', () => {
+    console.log(JSON.stringify(cache.store, null, 2));
     process.exit();
   })
   .option('-g, --git', 'attempt to append the git hash to the Workflow version during build from within the cliWd directory.', () => {
@@ -152,6 +157,21 @@ program
   });
 
 program
+  .command('cache <action>')
+  .description('Manage cache, actions: clear.')
+  .action((action: 'clear', property?: string, value?: string) => {
+    switch (action) {
+      case 'clear':
+        cache.clear();
+        break;
+      default:
+        console.log(`Error: ${action} not a valid action <clear>.`);
+
+        process.exit(1);
+    }
+  });
+
+program
   .command('login [username] [password]')
   .description('Login to acquire authentication tokens.')
   .action((username?: string, password?: string) => {
@@ -162,9 +182,10 @@ program
   .command('logout')
   .description('Logout to remove authentication tokens.')
   .action(() => {
-    config.delete('cliFolioAccessToken');
-    config.delete('cliFolioRefreshToken');
-    config.delete('cliFolioToken');
+    cache.delete('cliFolioAccessToken');
+    cache.delete('cliFolioRefreshToken');
+    cache.delete('cliFolioToken');
+    cache.delete('cliUserId');
 
     console.log('success');
   });

--- a/src/service/gateway.service.ts
+++ b/src/service/gateway.service.ts
@@ -16,15 +16,16 @@
 */
 const process = require('node:process');
 
+import { cache } from '../cache';
 import { config } from '../config';
 import { RestService } from './rest.service';
 
 class OkapiService extends RestService {
 
   public login(username: string = config.get('cliFolioUser'), password: string = config.get('cliFolioPass')): Promise<any> {
-    config.delete('cliFolioToken');
-    config.delete('cliFolioAccessToken');
-    config.delete('cliFolioRefreshToken');
+    cache.delete('cliFolioToken');
+    cache.delete('cliFolioAccessToken');
+    cache.delete('cliFolioRefreshToken');
 
     return new Promise((resolve, reject) => {
       this.request({
@@ -70,11 +71,11 @@ class OkapiService extends RestService {
           // The `accessToken` and `refreshToken` provide complete objects to use on HTTP requests.
           // If the `refreshToken` is an empty Object, then this must be a non-RTR access, so `accessToken.folioAccessToken` represents the `X-Okapi-Token`.
           if (!!accessToken?.folioAccessToken) {
-            config.set('cliFolioToken', accessToken.folioAccessToken);
-            config.set('cliFolioAccessToken', accessToken);
+            cache.set('cliFolioToken', accessToken.folioAccessToken);
+            cache.set('cliFolioAccessToken', accessToken);
 
             if (!!refreshToken?.folioRefreshToken) {
-              config.set('cliFolioRefreshToken', refreshToken);
+              cache.set('cliFolioRefreshToken', refreshToken);
             }
 
             resolve({
@@ -118,7 +119,7 @@ class OkapiService extends RestService {
 
           if (users?.length > 0) {
             const user = users[0]
-            config.set('cliUserId', user.id);
+            cache.set('cliUserId', user.id);
 
             resolve(user);
           } else {

--- a/src/service/rest.service.ts
+++ b/src/service/rest.service.ts
@@ -17,6 +17,7 @@
 const process = require('node:process');
 const request = require('request');
 
+import { cache } from '../cache';
 import { config } from '../config';
 
 export class RestService {
@@ -28,14 +29,14 @@ export class RestService {
    */
   public buildAccessHeaders(): Record<string, any> {
     const auth: Record<string, any> = {};
-    const accessToken: Record<string, any> = config.get('cliFolioAccessToken');
-    const refreshToken: Record<string, any> = config.get('cliFolioRefreshToken');
+    const accessToken: Record<string, any> = cache.get('cliFolioAccessToken');
+    const refreshToken: Record<string, any> = cache.get('cliFolioRefreshToken');
 
     if (!refreshToken?.folioRefreshToken) {
       auth['X-Okapi-Token'] = accessToken?.folioAccessToken;
     } else {
       if (accessToken?.folioAccessToken) {
-        auth['Cookie'] = `folioAccessToken=${accessToken.folioAccessToken}`;
+        auth.Cookie = `folioAccessToken=${accessToken.folioAccessToken}`;
       }
     }
 
@@ -124,7 +125,7 @@ export class RestService {
         }
       }, (error: any, resp?: any, body?: any) => {
         if (!!resp && resp?.statusCode >= 200 && resp?.statusCode <= 299) {
-          console.log("Delete succeeded.\n", url);
+          console.log('Delete succeeded.\n', url);
           resolve(body);
         } else {
           this.serviceError('Error: Failed to DELETE.', url, reject, body, error, resp);
@@ -159,7 +160,7 @@ export class RestService {
       },
       error: !!error
         ? error
-        : contentType == 'application/json' && typeof body == 'string'
+        : contentType === 'application/json' && typeof body === 'string'
           ? JSON.parse(body)
           : body,
     });

--- a/src/service/workflow.service.ts
+++ b/src/service/workflow.service.ts
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-const child_process = require('node:child_process');
+const childProcess = require('node:child_process');
 const process = require('node:process');
 
 import sha256 from 'crypto-js/sha256';
@@ -38,7 +38,7 @@ class WorkflowService extends RestService implements Enhancer {
    *
    * This should produce an identical hash to the command:
    *   ```sh
-   *   jq --sort-keys -cM 'del(.cliAccess, .cliDirectUrl, .cliFolioAccessToken, .cliFolioLoginPath, .cliFolioPass, .cliFolioRefreshToken, .cliFolioTenant, .cliFolioToken, .cliFolioUser, .cliGatewayUrl, .cliUserId, .cliWd)' config.json | sha256sum
+   *   jq --sort-keys -cM 'del(.cliAccess, .cliDirectUrl, .cliFolioLoginPath, .cliFolioPass, .cliFolioTenant, .cliFolioToken, .cliFolioUser, .cliGatewayUrl, .cliWd)' config.json | sha256sum
    *   ```
    * Where `config.json` is the configuration file.
    *
@@ -50,15 +50,11 @@ class WorkflowService extends RestService implements Enhancer {
     const toDelete = [
       'cliAccess',
       'cliDirectUrl',
-      'cliFolioAccessToken',
       'cliFolioLoginPath',
       'cliFolioPass',
-      'cliFolioRefreshToken',
       'cliFolioTenant',
-      'cliFolioToken',
       'cliFolioUser',
       'cliGatewayUrl',
-      'cliUserId',
       'cliWd`'
     ];
 
@@ -293,10 +289,10 @@ class WorkflowService extends RestService implements Enhancer {
 
     if (!cliWd) return false;
 
-    const command = "git rev-parse --short=12 HEAD";
-    const options = { "cwd": cliWd, encoding: 'utf8' };
+    const command = 'git rev-parse --short=12 HEAD';
+    const options = { 'cwd': cliWd, encoding: 'utf8' };
 
-    return child_process.execSync(command, options)?.trimEnd();
+    return childProcess.execSync(command, options)?.trimEnd();
   }
 
   /**
@@ -309,11 +305,11 @@ class WorkflowService extends RestService implements Enhancer {
   public getWd(): string {
     let wd = config.get('cliWd');
 
-    if (typeof wd != 'string') {
+    if (typeof wd !== 'string') {
       wd = '';
     }
 
-    if (wd == '') return './';
+    if (wd === '') return './';
 
     return wd.replace(/\/*$/, '/');
   }
@@ -460,7 +456,7 @@ class WorkflowService extends RestService implements Enhancer {
         if (suffix) {
           parsed.versionTag += `-${suffix}`;
         } else {
-          throw new Error("Git hash command returned no results in working directory (cliWd) path.");
+          throw new Error('Git hash command returned no results in working directory (cliWd) path.');
         }
       }
 
@@ -475,7 +471,7 @@ class WorkflowService extends RestService implements Enhancer {
   private getAccessUrl(): string {
     const access = config.get('cliAccess');
 
-    if (access == 'direct') {
+    if (access === 'direct') {
       return config.get('cliDirectUrl');
     }
 


### PR DESCRIPTION
## Purpose

Resolves #144 .


## Details

Break out the `cliFolioAccessToken`, `cliFolioRefreshToken`, `cliFolioToken`, and `cliUserId` into a separate cache file.

I just noticed that we have a linter.
Run the linter and fix all problems found.

Add command line parameters:
  - `-C` for showing the cache.

Add command line commands:
  - `cache`.

Currently only `clear` is supported for the cache.